### PR TITLE
feat: improve support for relationship queries (nested SELECTs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@salesforce/prettier-config": "^0.0.2",
     "@types/debounce": "^1.2.0",
     "@types/jest": "22.2.3",
-    "@types/vscode": "1.46.0",
+    "@types/vscode": "1.49.0",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",

--- a/src/completion/SoqlCompletionErrorStrategy.ts
+++ b/src/completion/SoqlCompletionErrorStrategy.ts
@@ -54,16 +54,13 @@ export class SoqlCompletionErrorStrategy extends DefaultErrorStrategy {
    */
   protected getErrorRecoverySet(recognizer: Parser): IntervalSet {
     const defaultRecoverySet = super.getErrorRecoverySet(recognizer);
-
     if (recognizer.ruleContext.ruleIndex === SoqlParser.RULE_soqlField) {
       const soqlFieldFollowSet = new IntervalSet();
       soqlFieldFollowSet.add(SoqlLexer.COMMA);
       soqlFieldFollowSet.add(SoqlLexer.FROM);
-
       const intersection = defaultRecoverySet.and(soqlFieldFollowSet);
       if (intersection.size > 0) return intersection;
     }
-
     return defaultRecoverySet;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,10 +793,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/vscode@1.46.0":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.46.0.tgz#53f2075986e901ed25cd1ec5f3ffa5db84a111b3"
-  integrity sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==
+"@types/vscode@1.49.0":
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.49.0.tgz#f3731d97d7e8b2697510eb26f6e6d04ee8c17352"
+  integrity sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==
 
 "@types/yargs-parser@*":
   version "20.2.0"


### PR DESCRIPTION
feat: complete nested FROM with parent-child relationships:
  SELECT (SELECT Id FROM |) FROM Account

feat: complete nested SELECT with fields of the relationship object:
  SELECT (SELECT | FROM Users) FROM Account

feat: complete nested ORDER BY with fields of the relationship object:
  SELECT (SELECT Id FROM Users ORDER BY |) FROM Account

fix: don't propose more than one level of SELECT nesting

fix: don't propose aggregate functions or GROUP BY on nested SELECT

feat: only propose Id fields on semi-join SELECTs

W-8558994