### PR TITLE
[W-21495820] feat: setup vscode-languageserver/browser

### DIFF
--- a/src/serverCore.ts
+++ b/src/serverCore.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Connection,
+  TextDocuments,
+  InitializeParams,
+  TextDocumentSyncKind,
+  InitializeResult,
+  TextDocumentPositionParams,
+  CompletionItem,
+  DidChangeWatchedFilesParams,
+  FileChangeType,
+  DocumentUri
+} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Validator } from './validator';
+import QueryValidationFeature from './query-validation-feature';
+import { completionsFor } from './completion';
+
+export function setupServerConnection(connection: Connection): void {
+  void connection.sendNotification('soql/validate', 'createConnection');
+
+  let runQueryValidation: boolean;
+
+  const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+
+  connection.onInitialize((params: InitializeParams) => {
+    runQueryValidation = QueryValidationFeature.hasRunQueryValidation(params.capabilities);
+    connection.console.log(`runQueryValidation: ${runQueryValidation}`);
+    const result: InitializeResult = {
+      capabilities: {
+        textDocumentSync: TextDocumentSyncKind.Full,
+        completionProvider: {
+          triggerCharacters: [' ']
+        }
+      }
+    };
+    return result;
+  });
+
+  function clearDiagnostics(uri: DocumentUri): void {
+    void connection.sendDiagnostics({ uri, diagnostics: [] });
+  }
+
+  documents.onDidClose(change => {
+    clearDiagnostics(change.document.uri);
+  });
+
+  /**
+   * NOTE: Listening on deleted files should NOT be necessary to trigger the clearing of Diagnostics,
+   * since the `documents.onDidClose()` callback should take care of it. However, for some reason,
+   * on automated tests of the SOQL VS Code extension, the 'workbench.action.close*Editor' commands
+   * don't trigger the `onDidClose()` callback on the language server side.
+   *
+   * So, to be safe (and to make tests green) we explicitly clear diagnostics also on deleted files:
+   */
+  connection.onDidChangeWatchedFiles((watchedFiles: DidChangeWatchedFilesParams) => {
+    const deletedUris = watchedFiles.changes
+      .filter(change => change.type === FileChangeType.Deleted)
+      .map(change => change.uri);
+    deletedUris.forEach(clearDiagnostics);
+  });
+
+  documents.onDidChangeContent(async change => {
+    const diagnostics = Validator.validateSoqlText(change.document);
+    await connection.sendDiagnostics({ uri: change.document.uri, diagnostics });
+
+    if (diagnostics.length === 0 && runQueryValidation) {
+      const remoteDiagnostics = await Validator.validateLimit0Query(change.document, connection);
+      if (remoteDiagnostics.length > 0) {
+        await connection.sendDiagnostics({ uri: change.document.uri, diagnostics: remoteDiagnostics });
+      }
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  connection.onCompletion(async (request: TextDocumentPositionParams): Promise<CompletionItem[]> => {
+    const doc = documents.get(request.textDocument.uri);
+    if (!doc) return [];
+
+    return completionsFor(doc.getText(), request.position.line + 1, request.position.character + 1);
+  });
+
+  documents.listen(connection);
+}

--- a/src/serverWorker.ts
+++ b/src/serverWorker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2026, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/serverWorker.ts
+++ b/src/serverWorker.ts
@@ -5,9 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
+/// <reference lib="webworker" />
+
+import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser';
 import { setupServerConnection } from './serverCore';
 
-const connection = createConnection(ProposedFeatures.all);
+const messageReader = new BrowserMessageReader(self);
+const messageWriter = new BrowserMessageWriter(self);
+const connection = createConnection(messageReader, messageWriter);
 setupServerConnection(connection);
 connection.listen();


### PR DESCRIPTION
### What does this PR do?
Setup `vscode-languageserver/browser` so that the SOQL extension can run in the web.

### What issues does this PR fix or reference?
@W-21495820@

### Testing
In soql-language-server (**daphne/W-21495820-setup-vscode-languageserver-browser** branch)
1. `yarn install`
2. `yarn build`
3. `yarn link`

In salesforcedx-vscode (**daphne/W-21452992-setup-vscode-languageclient-browser** branch)
1. `npm run reinstall` -> `npm run compile`
2. `yarn link @salesforce/soql-language-server`
3. `WIREIT_CACHE=none npm run vscode:bundle -w salesforcedx-vscode-services`
4. `WIREIT_CACHE=none npm run vscode:bundle -w salesforcedx-vscode-soql`
5. `npm run run:web -w salesforcedx-vscode-soql`

Confirm the following work as expected in web:
* Lazy loading works properly (Open command palette immediately after starting up the web worker and be able to see **SFDX: Create Query in SOQL Builder**) ✅
* SFDX: Execute SOQL Query... ✅
* SFDX: Execute SOQL Query With Currently Selected Text ✅
* SFDX: Create Query in SOQL Builder ✅
* SOQL Builder works ✅
* Can save the SOQL query ✅

In a .soql file
- Autocompletion ✅
- Correct coloring ✅
